### PR TITLE
Added kp-mate-dock-applet.conf so we can build mate-dock-applet.

### DIFF
--- a/packages.d/kp-mate-dock-applet.conf
+++ b/packages.d/kp-mate-dock-applet.conf
@@ -1,0 +1,14 @@
+KP_NAME=mate-dock-applet
+KP_VERSION=0.72
+KP_RELEASE=1
+
+KP_URL="${GIT_URL}"/kp-mate-dock-applet.git
+
+KP_UPSTREAM_SRC_TYPE=git
+KP_UPSTREAM_SRC_URL=https://github.com/robint99/mate-dock-applet
+KP_UPSTREAM_SRC_GIT_COMMIT=22e49277e17e4dc7cd6201a62d2609ae6e144f30
+
+KP_BUILD_SPEC=mate-dock-applet.spec
+
+KP_RELEASE_GIT_COMMIT=
+KP_DEPRECATED=no


### PR DESCRIPTION
Again you'd need my kp-mate-dock-applet github repo.

Also note, I've only successfully build the rpm, I haven't actually tested it.