### PR TITLE
Add fdupes to the base install

### DIFF
--- a/kickstart.d/korora-common-packages.ks
+++ b/kickstart.d/korora-common-packages.ks
@@ -114,7 +114,7 @@ openssh-askpass
 #rpm-sign
 strace
 vim
-
+fdupes
 
 #
 # DEVICE DRIVER / FIRMWARE MANAGEMENT


### PR DESCRIPTION
The fdupes tool provides a really simple and quick way
to find duplicated files on a filesystem with an option to
delete selected duplicates in a controlled way.