### PR TITLE
Remove package 'owncloud' from korora-xfce.ks

### DIFF
--- a/kickstart.d/korora-xfce.ks
+++ b/kickstart.d/korora-xfce.ks
@@ -103,7 +103,6 @@ ncftp
 network-manager-applet
 gst-transcoder
 pitivi
-owncloud
 pcsc-lite
 pcsc-lite-ccid
 #pharlap #no longer useful


### PR DESCRIPTION
I was shocked when I recommended the XFCE flavor to a developer friend of mine and he commented on a _full owncloud apache installation running in the background!_

I poked around the other kickstarts and none of them are specifying the entire `owncloud` "server" package. I'm thinking this was a mistake and the intention was to include `owncloud-client` package, but that is already being pulled in by the common packages kickstart.